### PR TITLE
Add spinner for loading state

### DIFF
--- a/browserExtension/background.js
+++ b/browserExtension/background.js
@@ -1,8 +1,0 @@
-chrome.action.onClicked.addListener((tab) => {
-    chrome.scripting.executeScript({
-      target: {tabId: tab.id},
-      func: () => {
-        console.log('Hello, world!');
-    }
-    });
-  });

--- a/browserExtension/index.html
+++ b/browserExtension/index.html
@@ -7,7 +7,13 @@
 </head>
 <body>
     <button id="myButton">Analyse reviews!</button>
+    <div id="loader"></div>
     <style>
+        body {
+            min-width: 150px;
+            display: flex;
+            justify-content: center;
+        }
         #myButton {
             background-color: #0067D5;
             border: none;
@@ -22,6 +28,26 @@
             padding: 12px;
             width: max-content;
         }
+
+        /* loader with animation */
+        
+        #loader {
+            animation: spin 2s linear infinite;
+            border: 6px solid #f3f3f3;
+            border-top: 6px solid #3498db;
+            border-radius: 50%;
+            width: 40px;
+            height: 40px;
+            margin-left: 10px;
+            display: none;
+            box-sizing: border-box;
+        }
+
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+
     </style>
     <script src="index.js"></script>
 </body>

--- a/browserExtension/index.js
+++ b/browserExtension/index.js
@@ -1,4 +1,11 @@
 async function detectFakeReviews() {
+    chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+        document.getElementById('myButton').style.display = 'block';
+        document.getElementById('loader').style.display = 'none';
+    });
+
+    document.getElementById('myButton').style.display = 'none';
+    document.getElementById('loader').style.display = 'block';
 
     let [tab] = await chrome.tabs.query({ active: true });
     chrome.scripting.executeScript({
@@ -98,6 +105,8 @@ async function detectFakeReviews() {
                             summary: "This review is trustworthy. The reviewer has reviewed multiple products and has a high helpfulness score."
                         }
                     ];
+                }).finally(() => {
+                    chrome.runtime.sendMessage({message: 'done'});
                 });
             } catch (error) {
                 console.error(error);

--- a/browserExtension/manifest.json
+++ b/browserExtension/manifest.json
@@ -10,10 +10,6 @@
         "24": "icons/icon24.png",
         "128": "icons/icon128.png"
       },
-    "background": {
-        "service_worker": "background.js",
-        "type": "module"
-    },
     "permissions": [
         "scripting",
         "tabs"


### PR DESCRIPTION
This pull request adds a spinner to indicate the loading state when the "Analyse reviews!" button is clicked. The spinner is displayed while the reviews are being analyzed and is hidden once the analysis is complete.